### PR TITLE
Implement authentication activity and view model

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,12 +15,17 @@
         android:theme="@style/Theme.USTHGitHubClient"
         tools:targetApi="31">
         <activity
+            android:name=".activities.AuthenticationActivity"
+            android:exported="false" />
+        <activity
             android:name=".activities.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>
+
 </manifest>

--- a/app/src/main/java/com/usth/githubclient/activities/AuthenticationActivity.java
+++ b/app/src/main/java/com/usth/githubclient/activities/AuthenticationActivity.java
@@ -1,0 +1,110 @@
+package com.usth.githubclient.activities;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.View;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
+
+import com.usth.githubclient.R;
+import com.usth.githubclient.databinding.ActivityAuthenticationBinding;
+import com.usth.githubclient.viewmodel.AuthViewModel;
+import com.usth.githubclient.viewmodel.AuthViewModel.AuthUiState;
+
+/**
+ * Presents the authentication screen and reacts to login events.
+ */
+public class AuthenticationActivity extends AppCompatActivity {
+
+    private ActivityAuthenticationBinding binding;
+    private AuthViewModel viewModel;
+    private TextWatcher tokenWatcher;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        binding = ActivityAuthenticationBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        viewModel = new ViewModelProvider(this).get(AuthViewModel.class);
+
+        setupListeners();
+        observeViewModel();
+    }
+
+    private void setupListeners() {
+        binding.signInButton.setOnClickListener(v -> viewModel.authenticate(getTokenInput()));
+        binding.mockDataButton.setOnClickListener(v -> viewModel.useMockSession());
+
+        tokenWatcher = new SimpleTextWatcher() {
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                binding.tokenInputLayout.setError(null);
+                binding.errorMessage.setVisibility(View.GONE);
+                viewModel.clearError();
+            }
+        };
+        binding.personalAccessTokenInput.addTextChangedListener(tokenWatcher);
+    }
+
+    private void observeViewModel() {
+        viewModel.getUiState().observe(this, this::renderState);
+    }
+
+    private void renderState(@Nullable AuthUiState state) {
+        if (state == null) {
+            return;
+        }
+
+        boolean loading = state.isLoading();
+        binding.progressBar.setVisibility(loading ? View.VISIBLE : View.GONE);
+        binding.personalAccessTokenInput.setEnabled(!loading);
+        binding.signInButton.setEnabled(!loading);
+        binding.mockDataButton.setEnabled(!loading);
+
+        if (state.getErrorMessage() != null) {
+            binding.tokenInputLayout.setError(state.getErrorMessage());
+            binding.errorMessage.setText(state.getErrorMessage());
+            binding.errorMessage.setVisibility(View.VISIBLE);
+        } else {
+            binding.tokenInputLayout.setError(null);
+            binding.errorMessage.setVisibility(View.GONE);
+        }
+
+        if (state.getSession() != null && !loading) {
+            binding.successMessage.setText(getString(R.string.auth_success_message,
+                    state.getSession().getUsername()));
+            binding.successMessage.setVisibility(View.VISIBLE);
+        } else {
+            binding.successMessage.setVisibility(View.GONE);
+        }
+    }
+
+    private String getTokenInput() {
+        CharSequence text = binding.personalAccessTokenInput.getText();
+        return text == null ? "" : text.toString();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (binding != null && tokenWatcher != null) {
+            binding.personalAccessTokenInput.removeTextChangedListener(tokenWatcher);
+        }
+        binding = null;
+        tokenWatcher = null;
+    }
+
+    private abstract static class SimpleTextWatcher implements TextWatcher {
+        @Override
+        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+        }
+
+        @Override
+        public void afterTextChanged(Editable s) {
+        }
+    }
+}

--- a/app/src/main/java/com/usth/githubclient/data/remote/ApiClient.java
+++ b/app/src/main/java/com/usth/githubclient/data/remote/ApiClient.java
@@ -1,0 +1,63 @@
+package com.usth.githubclient.data.remote;
+
+import java.util.concurrent.TimeUnit;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+/**
+ * Builds Retrofit clients used to talk to the GitHub REST API.
+ */
+public final class ApiClient {
+
+    private static final String BASE_URL = "https://api.github.com/";
+
+    private final Retrofit retrofit;
+    private volatile String authToken;
+
+    public ApiClient() {
+        OkHttpClient client = new OkHttpClient.Builder()
+                .addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
+                .addInterceptor(this::applyDefaultHeaders)
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build();
+
+        retrofit = new Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
+    }
+
+    private Response applyDefaultHeaders(Interceptor.Chain chain) throws java.io.IOException {
+        Request original = chain.request();
+        Request.Builder builder = original.newBuilder()
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28");
+
+        String token = authToken;
+        if (token != null && !token.isEmpty()) {
+            builder.header("Authorization", "Bearer " + token);
+        }
+
+        return chain.proceed(builder.build());
+    }
+
+    public GithubApiService createGithubApiService() {
+        return retrofit.create(GithubApiService.class);
+    }
+
+    public void setAuthToken(String authToken) {
+        this.authToken = authToken;
+    }
+
+    public void clearAuthToken() {
+        authToken = null;
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/data/remote/GithubApiService.java
+++ b/app/src/main/java/com/usth/githubclient/data/remote/GithubApiService.java
@@ -1,0 +1,57 @@
+package com.usth.githubclient.data.remote;
+
+import com.usth.githubclient.data.remote.dto.RepoDto;
+import com.usth.githubclient.data.remote.dto.UserDto;
+import java.util.List;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+/**
+ * Retrofit service definition for the GitHub REST API endpoints used by the app.
+ */
+public interface GithubApiService {
+
+    @GET("users/{username}")
+    Call<UserDto> getUser(@Path("username") String username);
+
+    @GET("users/{username}/followers")
+    Call<List<UserDto>> getFollowers(
+            @Path("username") String username,
+            @Query("per_page") int perPage,
+            @Query("page") int page
+    );
+
+    @GET("users/{username}/following")
+    Call<List<UserDto>> getFollowing(
+            @Path("username") String username,
+            @Query("per_page") int perPage,
+            @Query("page") int page
+    );
+
+    @GET("users/{username}/repos")
+    Call<List<RepoDto>> getUserRepositories(
+            @Path("username") String username,
+            @Query("per_page") int perPage,
+            @Query("page") int page,
+            @Query("sort") String sort
+    );
+
+    @GET("repos/{owner}/{repo}")
+    Call<RepoDto> getRepository(
+            @Path("owner") String owner,
+            @Path("repo") String repo
+    );
+
+    @GET("user")
+    Call<UserDto> getAuthenticatedUser();
+
+    @GET("user/repos")
+    Call<List<RepoDto>> getAuthenticatedRepositories(
+            @Query("per_page") int perPage,
+            @Query("page") int page,
+            @Query("sort") String sort
+    );
+}
+

--- a/app/src/main/java/com/usth/githubclient/data/remote/dto/RepoDto.java
+++ b/app/src/main/java/com/usth/githubclient/data/remote/dto/RepoDto.java
@@ -1,0 +1,132 @@
+package com.usth.githubclient.data.remote.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Raw representation of a GitHub repository as returned by the REST API.
+ */
+public final class RepoDto {
+
+    @SerializedName("id")
+    private long id;
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("full_name")
+    private String fullName;
+
+    @SerializedName("description")
+    private String description;
+
+    @SerializedName("language")
+    private String language;
+
+    @SerializedName("stargazers_count")
+    private int stargazersCount;
+
+    @SerializedName("forks_count")
+    private int forksCount;
+
+    @SerializedName("watchers_count")
+    private int watchersCount;
+
+    @SerializedName("open_issues_count")
+    private int openIssuesCount;
+
+    @SerializedName("html_url")
+    private String htmlUrl;
+
+    @SerializedName("default_branch")
+    private String defaultBranch;
+
+    @SerializedName("private")
+    private boolean isPrivate;
+
+    @SerializedName("fork")
+    private boolean isFork;
+
+    @SerializedName("created_at")
+    private String createdAt;
+
+    @SerializedName("updated_at")
+    private String updatedAt;
+
+    @SerializedName("pushed_at")
+    private String pushedAt;
+
+    @SerializedName("owner")
+    private UserDto owner;
+
+    /** Required by Gson. */
+    public RepoDto() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public int getStargazersCount() {
+        return stargazersCount;
+    }
+
+    public int getForksCount() {
+        return forksCount;
+    }
+
+    public int getWatchersCount() {
+        return watchersCount;
+    }
+
+    public int getOpenIssuesCount() {
+        return openIssuesCount;
+    }
+
+    public String getHtmlUrl() {
+        return htmlUrl;
+    }
+
+    public String getDefaultBranch() {
+        return defaultBranch;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    public boolean isFork() {
+        return isFork;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public String getPushedAt() {
+        return pushedAt;
+    }
+
+    public UserDto getOwner() {
+        return owner;
+    }
+}

--- a/app/src/main/java/com/usth/githubclient/data/remote/dto/UserDto.java
+++ b/app/src/main/java/com/usth/githubclient/data/remote/dto/UserDto.java
@@ -1,0 +1,118 @@
+package com.usth.githubclient.data.remote.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Raw representation of a GitHub user as returned by the public REST API.
+ */
+public final class UserDto {
+
+    @SerializedName("id")
+    private long id;
+
+    @SerializedName("login")
+    private String login;
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("avatar_url")
+    private String avatarUrl;
+
+    @SerializedName("bio")
+    private String bio;
+
+    @SerializedName("company")
+    private String company;
+
+    @SerializedName("blog")
+    private String blog;
+
+    @SerializedName("email")
+    private String email;
+
+    @SerializedName("location")
+    private String location;
+
+    @SerializedName("public_repos")
+    private int publicRepos;
+
+    @SerializedName("followers")
+    private int followers;
+
+    @SerializedName("following")
+    private int following;
+
+    @SerializedName("html_url")
+    private String htmlUrl;
+
+    @SerializedName("created_at")
+    private String createdAt;
+
+    @SerializedName("updated_at")
+    private String updatedAt;
+
+    /** Required by Gson. */
+    public UserDto() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public String getCompany() {
+        return company;
+    }
+
+    public String getBlog() {
+        return blog;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public int getPublicRepos() {
+        return publicRepos;
+    }
+
+    public int getFollowers() {
+        return followers;
+    }
+
+    public int getFollowing() {
+        return following;
+    }
+
+    public String getHtmlUrl() {
+        return htmlUrl;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/app/src/main/java/com/usth/githubclient/data/repository/AuthRepository.java
+++ b/app/src/main/java/com/usth/githubclient/data/repository/AuthRepository.java
@@ -1,0 +1,115 @@
+package com.usth.githubclient.data.repository;
+
+import com.usth.githubclient.data.remote.ApiClient;
+import com.usth.githubclient.data.remote.GithubApiService;
+import com.usth.githubclient.data.remote.dto.RepoDto;
+import com.usth.githubclient.data.remote.dto.UserDto;
+import com.usth.githubclient.domain.mapper.RepoMapper;
+import com.usth.githubclient.domain.mapper.UserMapper;
+import com.usth.githubclient.domain.model.GitHubUserProfileDataEntry;
+import com.usth.githubclient.domain.model.ReposDataEntry;
+import com.usth.githubclient.domain.model.UserSessionData;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import retrofit2.Response;
+
+/**
+ * Handles authentication using a personal access token and exposes the resulting session data.
+ */
+public final class AuthRepository {
+
+    private static final int DEFAULT_REPO_PAGE = 1;
+    private static final int DEFAULT_REPO_PER_PAGE = 30;
+    private static final String DEFAULT_SORT = "updated";
+
+    private final ApiClient apiClient;
+    private final GithubApiService apiService;
+    private final UserMapper userMapper;
+    private final RepoMapper repoMapper;
+
+    private UserSessionData cachedSession;
+
+    public AuthRepository(
+            ApiClient apiClient,
+            GithubApiService apiService,
+            UserMapper userMapper,
+            RepoMapper repoMapper
+    ) {
+        this.apiClient = Objects.requireNonNull(apiClient, "apiClient == null");
+        this.apiService = Objects.requireNonNull(apiService, "apiService == null");
+        this.userMapper = Objects.requireNonNull(userMapper, "userMapper == null");
+        this.repoMapper = Objects.requireNonNull(repoMapper, "repoMapper == null");
+    }
+
+    public UserSessionData authenticate(String personalAccessToken) throws IOException {
+        if (personalAccessToken == null || personalAccessToken.isEmpty()) {
+            throw new IllegalArgumentException("personalAccessToken cannot be null or empty");
+        }
+
+        apiClient.setAuthToken(personalAccessToken);
+
+        GitHubUserProfileDataEntry profile = fetchAuthenticatedUser();
+        List<ReposDataEntry> repositories = fetchAuthenticatedRepositories();
+
+        cachedSession = new UserSessionData(
+                profile.getUsername(),
+                personalAccessToken,
+                "Bearer",
+                null,
+                Instant.now().toString(),
+                profile,
+                repositories
+        );
+        return cachedSession;
+    }
+
+    public void signOut() {
+        cachedSession = null;
+        apiClient.clearAuthToken();
+    }
+
+    public UserSessionData getCachedSession() {
+        return cachedSession;
+    }
+
+    private GitHubUserProfileDataEntry fetchAuthenticatedUser() throws IOException {
+        Response<UserDto> response = apiService.getAuthenticatedUser().execute();
+        if (response.isSuccessful() && response.body() != null) {
+            return userMapper.map(response.body());
+        }
+        apiClient.clearAuthToken();
+        throw buildException("Unable to fetch authenticated user", response);
+    }
+
+    private List<ReposDataEntry> fetchAuthenticatedRepositories() throws IOException {
+        Response<List<RepoDto>> response = apiService
+                .getAuthenticatedRepositories(DEFAULT_REPO_PER_PAGE, DEFAULT_REPO_PAGE, DEFAULT_SORT)
+                .execute();
+        if (response.isSuccessful() && response.body() != null) {
+            return repoMapper.mapList(response.body());
+        }
+        if (response != null && response.code() == 404) {
+            return Collections.emptyList();
+        }
+        throw buildException("Unable to fetch repositories for authenticated user", response);
+    }
+
+    private IOException buildException(String message, Response<?> response) {
+        String errorBody;
+        try {
+            errorBody = response != null && response.errorBody() != null
+                    ? response.errorBody().string()
+                    : null;
+        } catch (IOException ignored) {
+            errorBody = null;
+        }
+        if (errorBody == null || errorBody.isEmpty()) {
+            return new IOException(message);
+        }
+        return new IOException(message + ": " + errorBody);
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/data/repository/RepoRepository.java
+++ b/app/src/main/java/com/usth/githubclient/data/repository/RepoRepository.java
@@ -1,0 +1,84 @@
+package com.usth.githubclient.data.repository;
+
+import com.usth.githubclient.data.remote.GithubApiService;
+import com.usth.githubclient.data.remote.dto.RepoDto;
+import com.usth.githubclient.domain.mapper.RepoMapper;
+import com.usth.githubclient.domain.model.ReposDataEntry;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import retrofit2.Response;
+
+/**
+ * Repository encapsulating repository related API calls.
+ */
+public final class RepoRepository {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PER_PAGE = 30;
+    private static final String DEFAULT_SORT = "updated";
+
+    private final GithubApiService apiService;
+    private final RepoMapper repoMapper;
+
+    public RepoRepository(GithubApiService apiService, RepoMapper repoMapper) {
+        this.apiService = Objects.requireNonNull(apiService, "apiService == null");
+        this.repoMapper = Objects.requireNonNull(repoMapper, "repoMapper == null");
+    }
+
+    public List<ReposDataEntry> fetchUserRepositories(String username) throws IOException {
+        return fetchUserRepositories(username, DEFAULT_PER_PAGE, DEFAULT_PAGE, DEFAULT_SORT);
+    }
+
+    public List<ReposDataEntry> fetchUserRepositories(
+            String username,
+            int perPage,
+            int page,
+            String sort
+    ) throws IOException {
+        Response<List<RepoDto>> response =
+                apiService.getUserRepositories(username, perPage, page, sort).execute();
+        if (response.isSuccessful() && response.body() != null) {
+            return repoMapper.mapList(response.body());
+        }
+        throw buildException("Unable to fetch repositories for " + username, response);
+    }
+
+    public List<ReposDataEntry> fetchAuthenticatedRepositories() throws IOException {
+        return fetchAuthenticatedRepositories(DEFAULT_PER_PAGE, DEFAULT_PAGE, DEFAULT_SORT);
+    }
+
+    public List<ReposDataEntry> fetchAuthenticatedRepositories(int perPage, int page, String sort)
+            throws IOException {
+        Response<List<RepoDto>> response =
+                apiService.getAuthenticatedRepositories(perPage, page, sort).execute();
+        if (response.isSuccessful() && response.body() != null) {
+            return repoMapper.mapList(response.body());
+        }
+        throw buildException("Unable to fetch repositories for the authenticated user", response);
+    }
+
+    public ReposDataEntry fetchRepository(String owner, String name) throws IOException {
+        Response<RepoDto> response = apiService.getRepository(owner, name).execute();
+        if (response.isSuccessful() && response.body() != null) {
+            return repoMapper.map(response.body());
+        }
+        throw buildException("Unable to fetch repository " + owner + "/" + name, response);
+    }
+
+    private IOException buildException(String message, Response<?> response) {
+        String errorBody;
+        try {
+            errorBody = response != null && response.errorBody() != null
+                    ? response.errorBody().string()
+                    : null;
+        } catch (IOException ignored) {
+            errorBody = null;
+        }
+        if (errorBody == null || errorBody.isEmpty()) {
+            return new IOException(message);
+        }
+        return new IOException(message + ": " + errorBody);
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/data/repository/UserRepository.java
+++ b/app/src/main/java/com/usth/githubclient/data/repository/UserRepository.java
@@ -1,0 +1,77 @@
+package com.usth.githubclient.data.repository;
+
+import com.usth.githubclient.data.remote.GithubApiService;
+import com.usth.githubclient.data.remote.dto.UserDto;
+import com.usth.githubclient.domain.mapper.UserMapper;
+import com.usth.githubclient.domain.model.GitHubUserProfileDataEntry;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import retrofit2.Response;
+
+/**
+ * Repository that handles remote user related requests.
+ */
+public final class UserRepository {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PER_PAGE = 30;
+
+    private final GithubApiService apiService;
+    private final UserMapper userMapper;
+
+    public UserRepository(GithubApiService apiService, UserMapper userMapper) {
+        this.apiService = Objects.requireNonNull(apiService, "apiService == null");
+        this.userMapper = Objects.requireNonNull(userMapper, "userMapper == null");
+    }
+
+    public GitHubUserProfileDataEntry fetchUserProfile(String username) throws IOException {
+        Response<UserDto> response = apiService.getUser(username).execute();
+        if (response.isSuccessful() && response.body() != null) {
+            return userMapper.map(response.body());
+        }
+        throw buildException("Unable to fetch profile for " + username, response);
+    }
+
+    public List<GitHubUserProfileDataEntry> fetchFollowers(String username) throws IOException {
+        return fetchFollowers(username, DEFAULT_PER_PAGE, DEFAULT_PAGE);
+    }
+
+    public List<GitHubUserProfileDataEntry> fetchFollowers(String username, int perPage, int page)
+            throws IOException {
+        Response<List<UserDto>> response = apiService.getFollowers(username, perPage, page).execute();
+        if (response.isSuccessful() && response.body() != null) {
+            return userMapper.mapList(response.body());
+        }
+        throw buildException("Unable to fetch followers for " + username, response);
+    }
+
+    public List<GitHubUserProfileDataEntry> fetchFollowing(String username) throws IOException {
+        return fetchFollowing(username, DEFAULT_PER_PAGE, DEFAULT_PAGE);
+    }
+
+    public List<GitHubUserProfileDataEntry> fetchFollowing(String username, int perPage, int page)
+            throws IOException {
+        Response<List<UserDto>> response = apiService.getFollowing(username, perPage, page).execute();
+        if (response.isSuccessful() && response.body() != null) {
+            return userMapper.mapList(response.body());
+        }
+        throw buildException("Unable to fetch following for " + username, response);
+    }
+
+    private IOException buildException(String message, Response<?> response) {
+        String errorBody;
+        try {
+            errorBody = response != null && response.errorBody() != null
+                    ? response.errorBody().string()
+                    : null;
+        } catch (IOException ignored) {
+            errorBody = null;
+        }
+        if (errorBody == null || errorBody.isEmpty()) {
+            return new IOException(message);
+        }
+        return new IOException(message + ": " + errorBody);
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/di/ServiceLocator.java
+++ b/app/src/main/java/com/usth/githubclient/di/ServiceLocator.java
@@ -1,0 +1,82 @@
+package com.usth.githubclient.di;
+
+import com.usth.githubclient.data.remote.ApiClient;
+import com.usth.githubclient.data.remote.GithubApiService;
+import com.usth.githubclient.data.repository.AuthRepository;
+import com.usth.githubclient.data.repository.RepoRepository;
+import com.usth.githubclient.data.repository.UserRepository;
+import com.usth.githubclient.domain.mapper.RepoMapper;
+import com.usth.githubclient.domain.mapper.UserMapper;
+
+/**
+ * Simple service locator used during the early stages of the project before a full DI solution
+ * is introduced.
+ */
+public final class ServiceLocator {
+
+    private static volatile ServiceLocator instance;
+
+    private final ApiClient apiClient;
+    private final GithubApiService githubApiService;
+    private final UserMapper userMapper;
+    private final RepoMapper repoMapper;
+    private final UserRepository userRepository;
+    private final RepoRepository repoRepository;
+    private final AuthRepository authRepository;
+
+    private ServiceLocator() {
+        apiClient = new ApiClient();
+        githubApiService = apiClient.createGithubApiService();
+        userMapper = new UserMapper();
+        repoMapper = new RepoMapper(userMapper);
+        userRepository = new UserRepository(githubApiService, userMapper);
+        repoRepository = new RepoRepository(githubApiService, repoMapper);
+        authRepository = new AuthRepository(apiClient, githubApiService, userMapper, repoMapper);
+    }
+
+    public static ServiceLocator getInstance() {
+        if (instance == null) {
+            synchronized (ServiceLocator.class) {
+                if (instance == null) {
+                    instance = new ServiceLocator();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public ApiClient apiClient() {
+        return apiClient;
+    }
+
+    public GithubApiService githubApiService() {
+        return githubApiService;
+    }
+
+    public UserMapper userMapper() {
+        return userMapper;
+    }
+
+    public RepoMapper repoMapper() {
+        return repoMapper;
+    }
+
+    public UserRepository userRepository() {
+        return userRepository;
+    }
+
+    public RepoRepository repoRepository() {
+        return repoRepository;
+    }
+
+    public AuthRepository authRepository() {
+        return authRepository;
+    }
+
+    public static void reset() {
+        synchronized (ServiceLocator.class) {
+            instance = null;
+        }
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/domain/mapper/RepoMapper.java
+++ b/app/src/main/java/com/usth/githubclient/domain/mapper/RepoMapper.java
@@ -1,0 +1,85 @@
+package com.usth.githubclient.domain.mapper;
+
+import com.usth.githubclient.data.remote.dto.RepoDto;
+import com.usth.githubclient.data.remote.dto.UserDto;
+import com.usth.githubclient.domain.model.GitHubUserProfileDataEntry;
+import com.usth.githubclient.domain.model.ReposDataEntry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Maps repository DTOs into domain models.
+ */
+public final class RepoMapper {
+
+    private final UserMapper userMapper;
+
+    public RepoMapper(UserMapper userMapper) {
+        this.userMapper = Objects.requireNonNull(userMapper, "userMapper == null");
+    }
+
+    public ReposDataEntry map(RepoDto dto) {
+        Objects.requireNonNull(dto, "dto == null");
+
+        String name = normalize(dto.getName());
+        String htmlUrl = normalize(dto.getHtmlUrl());
+        if (name == null || htmlUrl == null) {
+            throw new IllegalArgumentException("Repository name and htmlUrl are required");
+        }
+
+        GitHubUserProfileDataEntry owner = null;
+        UserDto ownerDto = dto.getOwner();
+        if (ownerDto != null) {
+            owner = userMapper.map(ownerDto);
+        }
+
+        return new ReposDataEntry(
+                dto.getId(),
+                name,
+                normalize(dto.getFullName()),
+                normalize(dto.getDescription()),
+                normalize(dto.getLanguage()),
+                safeCount(dto.getStargazersCount()),
+                safeCount(dto.getForksCount()),
+                safeCount(dto.getWatchersCount()),
+                safeCount(dto.getOpenIssuesCount()),
+                htmlUrl,
+                normalize(dto.getDefaultBranch()),
+                dto.isPrivate(),
+                dto.isFork(),
+                normalize(dto.getCreatedAt()),
+                normalize(dto.getUpdatedAt()),
+                normalize(dto.getPushedAt()),
+                owner
+        );
+    }
+
+    public List<ReposDataEntry> mapList(List<RepoDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<ReposDataEntry> result = new ArrayList<>(dtos.size());
+        for (RepoDto dto : dtos) {
+            if (dto == null) {
+                continue;
+            }
+            result.add(map(dto));
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private int safeCount(int count) {
+        return Math.max(count, 0);
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/domain/mapper/UserMapper.java
+++ b/app/src/main/java/com/usth/githubclient/domain/mapper/UserMapper.java
@@ -1,0 +1,68 @@
+package com.usth.githubclient.domain.mapper;
+
+import com.usth.githubclient.data.remote.dto.UserDto;
+import com.usth.githubclient.domain.model.GitHubUserProfileDataEntry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Maps {@link UserDto} values from the data layer into domain models.
+ */
+public final class UserMapper {
+
+    public GitHubUserProfileDataEntry map(UserDto dto) {
+        Objects.requireNonNull(dto, "dto == null");
+
+        String username = normalize(dto.getLogin());
+        if (username == null) {
+            throw new IllegalArgumentException("User login cannot be null or blank");
+        }
+
+        return new GitHubUserProfileDataEntry(
+                dto.getId(),
+                username,
+                normalize(dto.getName()),
+                normalize(dto.getAvatarUrl()),
+                normalize(dto.getBio()),
+                normalize(dto.getCompany()),
+                normalize(dto.getBlog()),
+                normalize(dto.getEmail()),
+                normalize(dto.getLocation()),
+                safeCount(dto.getPublicRepos()),
+                safeCount(dto.getFollowers()),
+                safeCount(dto.getFollowing()),
+                normalize(dto.getHtmlUrl()),
+                normalize(dto.getCreatedAt()),
+                normalize(dto.getUpdatedAt())
+        );
+    }
+
+    public List<GitHubUserProfileDataEntry> mapList(List<UserDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<GitHubUserProfileDataEntry> result = new ArrayList<>(dtos.size());
+        for (UserDto dto : dtos) {
+            if (dto == null) {
+                continue;
+            }
+            result.add(map(dto));
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private int safeCount(int count) {
+        return Math.max(count, 0);
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/domain/model/GitHubUserProfileDataEntry.java
+++ b/app/src/main/java/com/usth/githubclient/domain/model/GitHubUserProfileDataEntry.java
@@ -1,0 +1,126 @@
+package com.usth.githubclient.domain.model;
+
+import java.util.Objects;
+
+/**
+ * Domain contract that represents a GitHub user profile.
+ *
+ * <p>The model is intentionally lightweight so it can be shared across layers without leaking
+ * networking concerns. Optional fields are represented with nullable references.</p>
+ */
+public final class GitHubUserProfileDataEntry {
+
+    private final long id;
+    private final String username;
+    private final String displayName;
+    private final String avatarUrl;
+    private final String bio;
+    private final String company;
+    private final String blogUrl;
+    private final String email;
+    private final String location;
+    private final int publicRepos;
+    private final int followers;
+    private final int following;
+    private final String profileUrl;
+    private final String createdAt;
+    private final String updatedAt;
+
+    public GitHubUserProfileDataEntry(
+            long id,
+            String username,
+            String displayName,
+            String avatarUrl,
+            String bio,
+            String company,
+            String blogUrl,
+            String email,
+            String location,
+            int publicRepos,
+            int followers,
+            int following,
+            String profileUrl,
+            String createdAt,
+            String updatedAt
+    ) {
+        if (id < 0L) {
+            throw new IllegalArgumentException("id must be greater than or equal to 0");
+        }
+        this.id = id;
+        this.username = Objects.requireNonNull(username, "username == null");
+        this.displayName = displayName;
+        this.avatarUrl = avatarUrl;
+        this.bio = bio;
+        this.company = company;
+        this.blogUrl = blogUrl;
+        this.email = email;
+        this.location = location;
+        this.publicRepos = Math.max(publicRepos, 0);
+        this.followers = Math.max(followers, 0);
+        this.following = Math.max(following, 0);
+        this.profileUrl = profileUrl;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public String getCompany() {
+        return company;
+    }
+
+    public String getBlogUrl() {
+        return blogUrl;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public int getPublicRepos() {
+        return publicRepos;
+    }
+
+    public int getFollowers() {
+        return followers;
+    }
+
+    public int getFollowing() {
+        return following;
+    }
+
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/domain/model/MockDataFactory.java
+++ b/app/src/main/java/com/usth/githubclient/domain/model/MockDataFactory.java
@@ -1,0 +1,181 @@
+package com.usth.githubclient.domain.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utility class that provides deterministic models for previewing the UI before the
+ * networking stack is wired up.
+ */
+public final class MockDataFactory {
+
+    private MockDataFactory() {
+    }
+
+    public static GitHubUserProfileDataEntry mockUserProfile() {
+        return new GitHubUserProfileDataEntry(
+                583231L,
+                "octocat",
+                "The Octocat",
+                "https://avatars.githubusercontent.com/u/583231?v=4",
+                "Friendly mock account for UI previews. Loves Kotlin and espresso tests.",
+                "GitHub",
+                "https://github.blog",
+                "octocat@github.com",
+                "San Francisco, CA",
+                42,
+                3580,
+                9,
+                "https://github.com/octocat",
+                "2011-01-25T18:44:36Z",
+                "2024-02-20T07:20:45Z"
+        );
+    }
+
+    public static List<ReposDataEntry> mockRepositories() {
+        return mockRepositories(mockUserProfile());
+    }
+
+    public static List<ReposDataEntry> mockRepositories(GitHubUserProfileDataEntry owner) {
+        GitHubUserProfileDataEntry repoOwner = owner == null ? mockUserProfile() : owner;
+        List<ReposDataEntry> repositories = new ArrayList<>();
+
+        repositories.add(new ReposDataEntry(
+                1296269L,
+                "hello-android",
+                repoOwner.getUsername() + "/hello-android",
+                "Sample Android project demonstrating UI states and repository usage.",
+                "Kotlin",
+                1280,
+                320,
+                980,
+                12,
+                "https://github.com/" + repoOwner.getUsername() + "/hello-android",
+                "main",
+                false,
+                false,
+                "2023-05-10T08:00:00Z",
+                "2024-02-18T16:30:00Z",
+                "2024-02-21T09:15:00Z",
+                repoOwner
+        ));
+
+        repositories.add(new ReposDataEntry(
+                9876543L,
+                "compose-showcase",
+                repoOwner.getUsername() + "/compose-showcase",
+                "Jetpack Compose components extracted from the GitHub Client UI.",
+                "Kotlin",
+                856,
+                210,
+                640,
+                4,
+                "https://github.com/" + repoOwner.getUsername() + "/compose-showcase",
+                "main",
+                false,
+                false,
+                "2022-07-05T07:45:00Z",
+                "2024-01-05T11:20:00Z",
+                "2024-02-28T17:10:00Z",
+                repoOwner
+        ));
+
+        repositories.add(new ReposDataEntry(
+                5550001L,
+                "github-analytics",
+                repoOwner.getUsername() + "/github-analytics",
+                "Dashboard showcasing charts built entirely from mock GitHub metrics.",
+                "TypeScript",
+                642,
+                98,
+                502,
+                7,
+                "https://github.com/" + repoOwner.getUsername() + "/github-analytics",
+                "develop",
+                false,
+                true,
+                "2021-11-12T05:30:00Z",
+                "2024-02-12T19:40:00Z",
+                "2024-03-02T13:05:00Z",
+                repoOwner
+        ));
+
+        return Collections.unmodifiableList(repositories);
+    }
+
+    public static List<GitHubUserProfileDataEntry> mockFollowers() {
+        List<GitHubUserProfileDataEntry> followers = new ArrayList<>();
+
+        followers.add(new GitHubUserProfileDataEntry(
+                1024L,
+                "android-dev",
+                "Android Dev",
+                "https://avatars.githubusercontent.com/u/1024?v=4",
+                "Builds delightful Android experiences and shares UI prototyping tips.",
+                "JetBrains",
+                "https://blog.jetbrains.com",
+                null,
+                "Amsterdam, NL",
+                75,
+                2500,
+                120,
+                "https://github.com/android-dev",
+                null,
+                null
+        ));
+
+        followers.add(new GitHubUserProfileDataEntry(
+                2048L,
+                "compose-wizard",
+                "Compose Wizard",
+                "https://avatars.githubusercontent.com/u/2048?v=4",
+                "Turns product mocks into silky smooth Compose layouts in minutes.",
+                "Compose Studio",
+                "https://compose.studio/blog",
+                null,
+                "Berlin, Germany",
+                34,
+                980,
+                75,
+                "https://github.com/compose-wizard",
+                null,
+                null
+        ));
+
+        followers.add(new GitHubUserProfileDataEntry(
+                4096L,
+                "design-systems",
+                "Design Systems Guild",
+                "https://avatars.githubusercontent.com/u/4096?v=4",
+                "Collective of designers and engineers working on reusable UI kits.",
+                "Systems Co.",
+                "https://design.systems",
+                null,
+                "New York, USA",
+                120,
+                5400,
+                260,
+                "https://github.com/design-systems",
+                null,
+                null
+        ));
+
+        return Collections.unmodifiableList(followers);
+    }
+
+    public static UserSessionData mockUserSession() {
+        GitHubUserProfileDataEntry profile = mockUserProfile();
+        List<ReposDataEntry> repositories = mockRepositories(profile);
+        return new UserSessionData(
+                profile.getUsername(),
+                "gho_mocktoken1234567890",
+                "Bearer",
+                "2024-12-31T23:59:59Z",
+                "2024-03-15T14:45:00Z",
+                profile,
+                repositories
+        );
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/domain/model/ReposDataEntry.java
+++ b/app/src/main/java/com/usth/githubclient/domain/model/ReposDataEntry.java
@@ -1,0 +1,137 @@
+package com.usth.githubclient.domain.model;
+
+import java.util.Objects;
+
+/**
+ * Domain representation of a GitHub repository.
+ */
+public final class ReposDataEntry {
+
+    private final long id;
+    private final String name;
+    private final String fullName;
+    private final String description;
+    private final String language;
+    private final int stargazersCount;
+    private final int forksCount;
+    private final int watchersCount;
+    private final int openIssuesCount;
+    private final String htmlUrl;
+    private final String defaultBranch;
+    private final boolean isPrivate;
+    private final boolean isFork;
+    private final String createdAt;
+    private final String updatedAt;
+    private final String pushedAt;
+    private final GitHubUserProfileDataEntry owner;
+
+    public ReposDataEntry(
+            long id,
+            String name,
+            String fullName,
+            String description,
+            String language,
+            int stargazersCount,
+            int forksCount,
+            int watchersCount,
+            int openIssuesCount,
+            String htmlUrl,
+            String defaultBranch,
+            boolean isPrivate,
+            boolean isFork,
+            String createdAt,
+            String updatedAt,
+            String pushedAt,
+            GitHubUserProfileDataEntry owner
+    ) {
+        if (id < 0L) {
+            throw new IllegalArgumentException("id must be greater than or equal to 0");
+        }
+        this.id = id;
+        this.name = Objects.requireNonNull(name, "name == null");
+        this.fullName = fullName;
+        this.description = description;
+        this.language = language;
+        this.stargazersCount = Math.max(stargazersCount, 0);
+        this.forksCount = Math.max(forksCount, 0);
+        this.watchersCount = Math.max(watchersCount, 0);
+        this.openIssuesCount = Math.max(openIssuesCount, 0);
+        this.htmlUrl = Objects.requireNonNull(htmlUrl, "htmlUrl == null");
+        this.defaultBranch = defaultBranch;
+        this.isPrivate = isPrivate;
+        this.isFork = isFork;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.pushedAt = pushedAt;
+        this.owner = owner;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public int getStargazersCount() {
+        return stargazersCount;
+    }
+
+    public int getForksCount() {
+        return forksCount;
+    }
+
+    public int getWatchersCount() {
+        return watchersCount;
+    }
+
+    public int getOpenIssuesCount() {
+        return openIssuesCount;
+    }
+
+    public String getHtmlUrl() {
+        return htmlUrl;
+    }
+
+    public String getDefaultBranch() {
+        return defaultBranch;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    public boolean isFork() {
+        return isFork;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public String getPushedAt() {
+        return pushedAt;
+    }
+
+    public GitHubUserProfileDataEntry getOwner() {
+        return owner;
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/domain/model/UserSessionData.java
+++ b/app/src/main/java/com/usth/githubclient/domain/model/UserSessionData.java
@@ -1,0 +1,71 @@
+package com.usth.githubclient.domain.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Simple in-memory representation of the authenticated session.
+ */
+public final class UserSessionData {
+
+    private final String username;
+    private final String accessToken;
+    private final String tokenType;
+    private final String accessTokenExpiration;
+    private final String lastSyncedAt;
+    private final GitHubUserProfileDataEntry userProfile;
+    private final List<ReposDataEntry> repositories;
+
+    public UserSessionData(
+            String username,
+            String accessToken,
+            String tokenType,
+            String accessTokenExpiration,
+            String lastSyncedAt,
+            GitHubUserProfileDataEntry userProfile,
+            List<ReposDataEntry> repositories
+    ) {
+        this.username = Objects.requireNonNull(username, "username == null");
+        this.accessToken = Objects.requireNonNull(accessToken, "accessToken == null");
+        this.tokenType = tokenType;
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.lastSyncedAt = lastSyncedAt;
+        this.userProfile = userProfile;
+        if (repositories == null || repositories.isEmpty()) {
+            this.repositories = Collections.emptyList();
+        } else {
+            this.repositories = Collections.unmodifiableList(new ArrayList<>(repositories));
+        }
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public String getAccessTokenExpiration() {
+        return accessTokenExpiration;
+    }
+
+    public String getLastSyncedAt() {
+        return lastSyncedAt;
+    }
+
+    public GitHubUserProfileDataEntry getUserProfile() {
+        return userProfile;
+    }
+
+    public List<ReposDataEntry> getRepositories() {
+        return repositories;
+    }
+}
+

--- a/app/src/main/java/com/usth/githubclient/viewmodel/AuthViewModel.java
+++ b/app/src/main/java/com/usth/githubclient/viewmodel/AuthViewModel.java
@@ -1,0 +1,121 @@
+package com.usth.githubclient.viewmodel;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import com.usth.githubclient.data.repository.AuthRepository;
+import com.usth.githubclient.di.ServiceLocator;
+import com.usth.githubclient.domain.model.MockDataFactory;
+import com.usth.githubclient.domain.model.UserSessionData;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * ViewModel responsible for handling authentication flows and exposing UI friendly state.
+ */
+public class AuthViewModel extends ViewModel {
+
+    private final AuthRepository authRepository;
+    private final ExecutorService executorService;
+    private final MutableLiveData<AuthUiState> uiState = new MutableLiveData<>(AuthUiState.idle());
+
+    public AuthViewModel() {
+        this(ServiceLocator.getInstance().authRepository());
+    }
+
+    public AuthViewModel(@NonNull AuthRepository authRepository) {
+        this.authRepository = Objects.requireNonNull(authRepository, "authRepository == null");
+        this.executorService = Executors.newSingleThreadExecutor();
+    }
+
+    public LiveData<AuthUiState> getUiState() {
+        return uiState;
+    }
+
+    public void authenticate(String personalAccessToken) {
+        final String token = personalAccessToken == null ? "" : personalAccessToken.trim();
+        if (token.isEmpty()) {
+            uiState.setValue(AuthUiState.error("Please enter a personal access token."));
+            return;
+        }
+
+        uiState.setValue(AuthUiState.loading());
+        executorService.execute(() -> {
+            try {
+                UserSessionData session = authRepository.authenticate(token);
+                uiState.postValue(AuthUiState.success(session));
+            } catch (IOException | RuntimeException exception) {
+                String message = exception.getMessage();
+                if (message == null || message.trim().isEmpty()) {
+                    message = "Authentication failed. Please try again.";
+                }
+                uiState.postValue(AuthUiState.error(message));
+            }
+        });
+    }
+
+    public void useMockSession() {
+        uiState.setValue(AuthUiState.success(MockDataFactory.mockUserSession()));
+    }
+
+    public void clearError() {
+        AuthUiState current = uiState.getValue();
+        if (current != null && current.getErrorMessage() != null) {
+            uiState.setValue(new AuthUiState(current.isLoading(), current.getSession(), null));
+        }
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        executorService.shutdownNow();
+    }
+
+    /**
+     * Represents the immutable state of the authentication screen.
+     */
+    public static final class AuthUiState {
+        private final boolean loading;
+        private final UserSessionData session;
+        private final String errorMessage;
+
+        private AuthUiState(boolean loading, UserSessionData session, String errorMessage) {
+            this.loading = loading;
+            this.session = session;
+            this.errorMessage = errorMessage;
+        }
+
+        public static AuthUiState idle() {
+            return new AuthUiState(false, null, null);
+        }
+
+        public static AuthUiState loading() {
+            return new AuthUiState(true, null, null);
+        }
+
+        public static AuthUiState success(UserSessionData session) {
+            return new AuthUiState(false, session, null);
+        }
+
+        public static AuthUiState error(String message) {
+            return new AuthUiState(false, null, message);
+        }
+
+        public boolean isLoading() {
+            return loading;
+        }
+
+        public UserSessionData getSession() {
+            return session;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_authentication.xml
+++ b/app/src/main/res/layout/activity_authentication.xml
@@ -1,4 +1,107 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/auth_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:text="@string/auth_title"
+        android:textAppearance="@style/TextAppearance.AppCompat.Large"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/auth_description"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/auth_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:text="@string/auth_description"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+        app:layout_constraintBottom_toTopOf="@id/token_input_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/token_input_layout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/auth_token_hint"
+        app:layout_constraintBottom_toTopOf="@id/sign_in_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/auth_description">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/personal_access_token_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:imeOptions="actionDone"
+            android:inputType="textPassword"
+            android:maxLines="1"
+            android:textColor="@android:color/black" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/sign_in_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/auth_sign_in"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/token_input_layout" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/mock_data_button"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="@string/auth_use_mock"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/sign_in_button" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mock_data_button" />
+
+    <TextView
+        android:id="@+id/error_message"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:textColor="@android:color/holo_red_dark"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/progress_bar" />
+
+    <TextView
+        android:id="@+id/success_message"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textColor="@android:color/holo_green_dark"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/error_message" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="app_name">USTH GitHub Client</string>
+    <string name="auth_title">Sign in with GitHub</string>
+    <string name="auth_description">Enter your personal access token to preview your GitHub data.</string>
+    <string name="auth_token_hint">Personal access token</string>
+    <string name="auth_sign_in">Sign in</string>
+    <string name="auth_use_mock">Preview with mock data</string>
+    <string name="auth_success_message">Welcome back, %1$s!</string>
 </resources>


### PR DESCRIPTION
## Summary
- create a login layout with material components, status messaging, and mock preview affordances
- wire AuthenticationActivity to the view binding and observe AuthViewModel state transitions
- implement AuthViewModel to authenticate asynchronously, expose UI state, and provide mock session previews
- register the authentication screen and add supporting string resources

## Testing
- `./gradlew test` *(fails: SDK location not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cea01241e88322a4da8881f60aa2b5